### PR TITLE
Add internationalization system

### DIFF
--- a/src/main/kotlin/com/bendev/ssdb/Bot.kt
+++ b/src/main/kotlin/com/bendev/ssdb/Bot.kt
@@ -4,11 +4,13 @@ import com.bendev.ssdb.database.SecretSantaDatabase
 import com.bendev.ssdb.listener.MessageListener
 import com.bendev.ssdb.listener.ReactionListener
 import com.bendev.ssdb.utils.Constant
+import com.bendev.ssdb.utils.I18nManager
 import com.bendev.ssdb.utils.properties.PropertiesManager
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.requests.GatewayIntent
 import java.io.IOException
+import java.util.*
 import javax.security.auth.login.LoginException
 
 class Bot {
@@ -34,6 +36,8 @@ class Bot {
         jda.presence.activity = Activity.playing(properties.playingAt)
 
         SecretSantaDatabase.initDatabse()
+
+        I18nManager.initWithLocale(Locale.forLanguageTag(properties.localeLanguage))
 
     }
 

--- a/src/main/kotlin/com/bendev/ssdb/utils/I18nManager.kt
+++ b/src/main/kotlin/com/bendev/ssdb/utils/I18nManager.kt
@@ -1,0 +1,15 @@
+package com.bendev.ssdb.utils
+
+import java.util.*
+
+object I18nManager {
+
+    private lateinit var _messageStrings: ResourceBundle
+    val messageStrings: ResourceBundle
+        get() = _messageStrings
+
+    fun initWithLocale(locale: Locale) {
+        _messageStrings = ResourceBundle.getBundle("messages", locale)
+    }
+
+}

--- a/src/main/kotlin/com/bendev/ssdb/utils/properties/Properties.kt
+++ b/src/main/kotlin/com/bendev/ssdb/utils/properties/Properties.kt
@@ -11,5 +11,7 @@ data class Properties(
         @SerialName("allowed_roles_list")
         var allowedRolesName: MutableList<String>,
         @SerialName("allowed_users_id_list")
-        var allowedUsersId: MutableList<String>
+        var allowedUsersId: MutableList<String>,
+        @SerialName("language")
+        val localeLanguage: String
 )

--- a/src/main/kotlin/com/bendev/ssdb/utils/properties/PropertiesManager.kt
+++ b/src/main/kotlin/com/bendev/ssdb/utils/properties/PropertiesManager.kt
@@ -53,10 +53,11 @@ object PropertiesManager {
 
     private fun initPropertiesFile(file: File) {
         val defaultProperties = Properties(
-            token = "",
-        playingAt = "",
-        allowedRolesName = mutableListOf(""),
-        allowedUsersId = mutableListOf("")
+                token = "",
+                playingAt = "",
+                allowedRolesName = mutableListOf(""),
+                allowedUsersId = mutableListOf(""),
+                localeLanguage = "Default"
         )
 
         val dataToWrite = json.encodeToString(Properties.serializer(), defaultProperties)

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+test = testDefault

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,1 @@
+test = testEN

--- a/src/main/resources/messages_fr.properties
+++ b/src/main/resources/messages_fr.properties
@@ -1,0 +1,1 @@
+test = testFR

--- a/src/test/kotlin/com/bendev/ssdb/utils/I18nManagerTest.kt
+++ b/src/test/kotlin/com/bendev/ssdb/utils/I18nManagerTest.kt
@@ -1,0 +1,74 @@
+package com.bendev.ssdb.utils
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+internal class I18nManagerTest {
+
+    @BeforeEach
+    fun init() {
+
+        // unknown country set to the default locale
+        Locale.setDefault(Locale.forLanguageTag("qwerty"))
+
+    }
+
+    @Test
+    fun givenFrenchLocale_whenInitI18nManager_thenReturnFrenchResources() {
+
+        // given French Locale
+        val locale = Locale.FRENCH
+
+        // when init I18nManager
+        I18nManager.initWithLocale(locale)
+
+        // then answer is testFR
+        assertTrue(I18nManager.messageStrings.getString("test") == "testFR")
+
+    }
+
+    @Test
+    fun givenEnglishLocale_whenInitI18nManager_thenReturnEnglishResources() {
+
+        // given English Locale
+        val locale = Locale.ENGLISH
+
+        // when init I18nManager
+        I18nManager.initWithLocale(locale)
+
+        // then answer is testEN
+        assertTrue(I18nManager.messageStrings.getString("test") == "testEN")
+
+    }
+
+    @Test
+    fun givenDefaultLocale_whenInitI18nManager_thenReturnDefaultResources() {
+
+        // given Default Locale
+        val locale = Locale.getDefault()
+
+        // when init I18nManager
+        I18nManager.initWithLocale(locale)
+
+        // then answer is testEN
+        assertTrue(I18nManager.messageStrings.getString("test") == "testDefault")
+
+    }
+
+    @Test
+    fun givenUnmanagedLocale_whenInitI18nManager_thenReturnDefaultResources() {
+
+        // given unmanaged Locale
+        val locale = Locale.TAIWAN
+
+        // when init I18nManager
+        I18nManager.initWithLocale(locale)
+
+        // then answer is OK
+        assertTrue(I18nManager.messageStrings.getString("test") == "testDefault")
+
+    }
+
+}


### PR DESCRIPTION
Internationalization (i18n) is made with ResourceBundle

- creation of files for each language that the bot could use
- creation of a manager to load the good resource file
- add a property in `properties.json` to allow the discord admin to set up the bot language